### PR TITLE
few things fixed

### DIFF
--- a/lib/rest-graph.rb
+++ b/lib/rest-graph.rb
@@ -225,9 +225,22 @@ class RestGraph < RestGraphStruct
       "#{str.tr('-_', '+/')}==".unpack('m').first
     }
     self.data = self.class.json_decode(json) if
-      secret && OpenSSL::HMAC.digest('sha256', secret, json_encoded) == sig
+      secret && hmac_digest(secret, json_encoded) == sig
   rescue ParseError
   end
+
+  # fallback to ruby gem if sha256 isn't available in system openssl lib
+
+  def hmac_digest key, data
+    begin
+      digest = OpenSSL::Digest::Digest.new('sha256')
+      return OpenSSL::HMAC.digest(digest, key, data)
+    rescue
+      require 'hmac-sha2'
+      return HMAC::SHA256.digest(key, data)
+    end
+  end
+
 
 
 

--- a/lib/rest-graph/rails_util.rb
+++ b/lib/rest-graph/rails_util.rb
@@ -87,6 +87,7 @@ module RestGraph::RailsUtil
 
   # override this if you want the simple redirect_to
   def rest_graph_authorize_redirect
+    cookies.delete "fbs_#{rest_graph.app_id}"
     if !rest_graph_oget(:iframe)
       redirect_to @rest_graph_authorize_url
     else

--- a/lib/rest-graph/rails_util.rb
+++ b/lib/rest-graph/rails_util.rb
@@ -39,8 +39,8 @@ module RestGraph::RailsUtil
     rest_graph_options_ctl.merge!(rest_graph_extract_options(options, :reject))
     rest_graph_options_new.merge!(rest_graph_extract_options(options, :select))
 
-    rest_graph_check_cookie                # for javascript sdk (canvas or not)
     rest_graph_check_params_signed_request # canvas
+    rest_graph_check_cookie                # for javascript sdk (canvas or not)
     rest_graph_check_params_session        # i think it would be deprecated
     rest_graph_check_code                  # oauth api
 
@@ -161,6 +161,7 @@ module RestGraph::RailsUtil
                  " #{rest_graph.data.inspect}")
 
     if rest_graph.authorized?
+      cookies.delete "fbs_#{rest_graph.app_id}"
       rest_graph_write_rg_fbs
     else
       logger.warn(


### PR DESCRIPTION
Hi!

We're developing an app that can work as an external facebook app and an iframe app simultaneously, and we've come along a few bugs that got fixed:
- If the app got authorized through a signed request, it deletes the Javascript API's fbs_ cookie, to prevent situations where the facebook session changes (for example multiple people using the same computer, loggin in and out after eachother). In case the session changed and the old cookie was still there, the JS API would recognize the old session as invalid and wouldn't get a new one.
- There are cases when a deauthorized session is still there in the fbs_ cookies, and rest-graph gets into an endless loop, trying to authenticate from the old cookie
- In the case of iframe apps authenticated thru signed requests, the fbs_ cookie must have a lower priority
- There was a bug with osx leopard 10.5 which has an outdated version of openssl (as a system library), and doesn't have an sha256 digest method. This patch makes rest-graph fals back to the ruby-hmac gem's HMAC::SHA256 method. I haven't updated the Gemspec because I don't know how to do it, I didn't want to mess it up so it's up to you to do it.

Thanks for this wonderful gem :)
