### PR TITLE
URI encoding

### DIFF
--- a/lib/rest-graph/core.rb
+++ b/lib/rest-graph/core.rb
@@ -303,7 +303,7 @@ class RestGraph < RestGraphStruct
 
   def next_page hash, opts={}, &cb
     if hash['paging'].kind_of?(Hash) && hash['paging']['next']
-      request(opts, [:get, hash['paging']['next']], &cb)
+      request(opts, [:get, URI.encode(hash['paging']['next'])], &cb)
     else
       yield(nil) if block_given?
     end
@@ -311,7 +311,7 @@ class RestGraph < RestGraphStruct
 
   def prev_page hash, opts={}, &cb
     if hash['paging'].kind_of?(Hash) && hash['paging']['previous']
-      request(opts, [:get, hash['paging']['previous']], &cb)
+      request(opts, [:get, URI.encode(hash['paging']['previous'])], &cb)
     else
       yield(nil) if block_given?
     end


### PR DESCRIPTION
It appears to me that FB is no longer URI encoding the next / previous page for the news stream ('me/home'). It's probably affecting any FB data structure that includes paging, but I haven't verified that. 

RestClient::Request.execute is now throwing "URI::InvalidURIError: bad URI(is not URI?)" when I try to fetch the next page. 

I've changed the code to properly encode the URL. I've run all your tests and they pass. Let me know if there's something else you'd like for this fix. 
