### PR TITLE
fix for verifying rest_graph_fbs_ within a facebook app flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,7 @@ group :test do
   gem 'rr'
   gem 'webmock'
   gem 'bacon'
+  if RUBY_VERSION >= '1.9.2'
+    gem 'psych'
+  end
 end

--- a/lib/rest-graph/core.rb
+++ b/lib/rest-graph/core.rb
@@ -351,8 +351,7 @@ class RestGraph < RestGraphStruct
     self.data = check_sig_and_return_data(
       # take out facebook sometimes there but sometimes not quotes in cookies
       Rack::Utils.parse_query(fbs.to_s.gsub('"', ''))) ||
-      check_sig_and_return_data(
-         Rack::Utils.parse_query(fbs.to_s))
+      check_sig_and_return_data(Rack::Utils.parse_query(fbs.to_s))
   end
 
   def parse_json! json

--- a/lib/rest-graph/core.rb
+++ b/lib/rest-graph/core.rb
@@ -350,7 +350,9 @@ class RestGraph < RestGraphStruct
   def parse_fbs! fbs
     self.data = check_sig_and_return_data(
       # take out facebook sometimes there but sometimes not quotes in cookies
-      Rack::Utils.parse_query(fbs.to_s.gsub('"', '')))
+      Rack::Utils.parse_query(fbs.to_s.gsub('"', ''))) ||
+      check_sig_and_return_data(
+         Rack::Utils.parse_query(fbs.to_s))
   end
 
   def parse_json! json

--- a/rest-graph.gemspec
+++ b/rest-graph.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors = [
   %q{Cardinal Blue},
   %q{Lin Jen-Shin (godfat)}]
-  s.date = %q{2011-05-26}
+  s.date = %q{2011-05-27}
   s.description = %q{A lightweight Facebook Graph API client}
   s.email = [%q{dev (XD) cardinalblue.com}]
   s.extra_rdoc_files = [
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.files = [
   %q{.gitignore},
   %q{.gitmodules},
+  %q{.rvmrc},
   %q{CHANGES},
   %q{CONTRIBUTORS},
   %q{Gemfile},
@@ -108,7 +109,7 @@ Gem::Specification.new do |s|
   %q{--main},
   %q{README}]
   s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.4}
+  s.rubygems_version = %q{1.8.3}
   s.summary = %q{A lightweight Facebook Graph API client}
   s.test_files = [
   %q{test/test_api.rb},


### PR DESCRIPTION
The sig verification in the rest_graph_fbs_ is failing within the facebook app flow. I ran into this specifically with the session_store.

My workaround involves verifying the sig without '"' and with.
